### PR TITLE
Add missing label back

### DIFF
--- a/pkg/controller/managementingress/handler/ingressrequest.go
+++ b/pkg/controller/managementingress/handler/ingressrequest.go
@@ -98,6 +98,7 @@ func (ingressRequest *IngressRequest) Delete(object runtime.Object) (err error) 
 func GetCommonLabels() map[string]string {
 	return map[string]string{
 		"app":                          AppName,
+		"component":                    AppName,
 		"app.kubernetes.io/component":  AppName,
 		"app.kubernetes.io/name":       AppName,
 		"app.kubernetes.io/instance":   ServiceName,


### PR DESCRIPTION
For service of management ingress it still use
component=managementingress as instance selector. Need to add the
label back for the deployment.