### PR TITLE
Update UBI base image for VAScan issues

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-328
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:39df7365f1343e9a49132f96edd852ddb80e4dcdec03ef8fe1779acb5418d37e
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f8174ab3c2fb4bd8aae29c48e077ba8e67c91904a639dd950b4c7e21c857cfec
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e55721eb97b2517542b695c3ad36e9534fb8f7a8641d06b2ad87e802e36dd8d2
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c4be843e7dbeeea865e7f93787f00d5e20c425a895ab56998c93bb6dc88abfe4
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:d41676554f34c417c82a016c94790179fb4116063547b757ec7a65a52235c9c8
 ARG VCS_REF
 ARG VCS_URL
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"reflect"
 
 	v1alpha1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
@@ -29,13 +27,6 @@ func AsOwner(o *v1alpha1.ManagementIngress) metav1.OwnerReference {
 		UID:        o.UID,
 		Controller: GetBool(true),
 	}
-}
-
-//CalculateMD5Hash returns a MD5 hash of the give text
-func CalculateMD5Hash(text string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(text))
-	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func AreMapsSame(lhs, rhs map[string]string) bool {


### PR DESCRIPTION
The current UBI base image has some vulnerable packages. Need to
update it to latest one which has updated packages.