### PR TITLE
Should restart operand pod when config was changed

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -17,11 +17,6 @@ rules:
   verbs:
   - create
   - list
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
   - use
 - apiGroups:
   - certmanager.k8s.io
@@ -30,46 +25,14 @@ rules:
   verbs:
   - use
 - apiGroups:
-    - ""
+  - certmanager.k8s.io
   resources:
-    - endpoints
-    - nodes
-    - pods
-    - secrets
+  - certificates
   verbs:
-    - list
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - configmaps
-  verbs:
-    - create
-    - get
-    - list
-    - update
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - nodes
-  verbs:
-    - get
-- apiGroups:
-    - ""
-  resources:
-    - services
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - events
-  verbs:
-    - create
-    - patch
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
     - "extensions"
     - "networking.k8s.io"
@@ -96,11 +59,20 @@ rules:
     - list
     - watch
 - apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
   - ""
   resources:
   - pods
   - services
   - services/finalizers
+  - serviceaccounts
   - endpoints
   - persistentvolumeclaims
   - events
@@ -138,19 +110,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-- apiGroups:
   - operator.ibm.com
   resources:
   - managementingresses
@@ -169,6 +128,9 @@ rules:
   - routes
   verbs:
   - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:
@@ -184,12 +146,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - certmanager.k8s.io
-  resources:
-  - certificates
-  verbs:
-  - create
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
@@ -200,4 +156,4 @@ rules:
   - list
   - patch
   - update
-  - watch      
+  - watch

--- a/deploy/olm-catalog/ibm-management-ingress-operator/0.0.1/ibm-management-ingress-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-management-ingress-operator/0.0.1/ibm-management-ingress-operator.v0.0.1.clusterserviceversion.yaml
@@ -156,13 +156,6 @@ spec:
           verbs:
           - create
           - list
-        - apiGroups:
-          - security.openshift.io
-          resourceNames:
-          - management-ingress-scc
-          resources:
-          - securitycontextconstraints
-          verbs:
           - use
         - apiGroups:
           - certmanager.k8s.io
@@ -171,46 +164,14 @@ spec:
           verbs:
           - use
         - apiGroups:
-            - ""
+          - certmanager.k8s.io
           resources:
-            - endpoints
-            - nodes
-            - pods
-            - secrets
+          - certificates
           verbs:
-            - list
-            - watch
-        - apiGroups:
-            - ""
-          resources:
-            - configmaps
-          verbs:
-            - create
-            - get
-            - list
-            - update
-            - watch
-        - apiGroups:
-            - ""
-          resources:
-            - nodes
-          verbs:
-            - get
-        - apiGroups:
-            - ""
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - ""
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
+          - create
+          - get
+          - list
+          - watch
         - apiGroups:
             - "extensions"
             - "networking.k8s.io"
@@ -237,11 +198,20 @@ spec:
             - list
             - watch
         - apiGroups:
+            - ""
+          resources:
+            - nodes
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
           - ""
           resources:
           - pods
           - services
           - services/finalizers
+          - serviceaccounts
           - endpoints
           - persistentvolumeclaims
           - events
@@ -279,26 +249,6 @@ spec:
           verbs:
           - update
         - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-        - apiGroups:
           - operator.ibm.com
           resources:
           - managementingresses
@@ -317,39 +267,22 @@ spec:
           - routes
           verbs:
           - create
-          - delete
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
-          - ""
           - route.openshift.io
           resources:
           - routes/custom-host
           verbs:
           - create
         - apiGroups:
-          - ""
           - route.openshift.io
           resources:
           - routes/status
           verbs:
           - get
           - list
-          - watch
-        - apiGroups:
-          - certmanager.k8s.io
-          resources:
-          - certificates
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - monitoring.coreos.com
@@ -362,7 +295,7 @@ spec:
           - list
           - patch
           - update
-          - watch              
+          - watch
         serviceAccountName: ibm-management-ingress-operator
     strategy: deployment
   installModes:

--- a/pkg/controller/managementingress/handler/configmap.go
+++ b/pkg/controller/managementingress/handler/configmap.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/IBM/ibm-management-ingress-operator/pkg/utils"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/apis/apps"
 )
 
 //NewConfigMap stubs an instance of Configmap


### PR DESCRIPTION
Fix issue when config of management ingress was changed the operator
should restart operand pod to let it pick up latest config.

Also refine the cluserrole needed by operator.