### PR TITLE
Change priority of scc to the lowest

### DIFF
--- a/pkg/controller/managementingress/handler/scc.go
+++ b/pkg/controller/managementingress/handler/scc.go
@@ -31,7 +31,7 @@ import (
 func NewSecurityContextConstraint(serviceaccount, name, namespace string) *scc.SecurityContextConstraints {
 	user := strings.Join([]string{"system:serviceaccount", name, namespace}, ":")
 	privilegeEscalation := false
-	var priority int32 = 10
+	var priority int32 = 1
 
 	labels := GetCommonLabels()
 


### PR DESCRIPTION
There is conflict with OCP default scc ((e.g., anyuid). For example,
if some of OCP pods were restarted it will by default select the
strict one with same priority. But the ingress nginx scc does not
allow run container with root user, which is not case for some of
OCP pods. Change the priority of scc to the lowest will fix this issue.