### PR TITLE
Added ibm-cloud-info configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Build the meta operator image and push it to a public registry, such as quay.io:
 
 ```bash
 # make build
-# make image
+# make images
 ```
 
 ### Installing

--- a/deploy/olm-catalog/ibm-management-ingress-operator/1.2.0/ibm-management-ingress-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-management-ingress-operator/1.2.0/ibm-management-ingress-operator.v1.2.0.clusterserviceversion.yaml
@@ -61,7 +61,26 @@ metadata:
               }
             ]
           }
+        },
+        {
+          "apiVersion": "odlm.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "name": "management-ingress"
+          },
+          "spec": {
+            "operand": "ibm-management-ingress-operator",
+            "registry": "common-service",
+            "bindings": {
+              "public": {
+                "secret": "ibmcloud-cluster-ca-cert",
+                "configmap": "ibmcloud-cluster-info"
+              }
+            }
+          }
         }
+      }
+    }
       ]
     capabilities: Basic Install
     categories: Developer Tools
@@ -204,6 +223,18 @@ spec:
                   value: ibm-management-ingress-operator
                 - name: OPERAND_IMAGE_DIGEST
                   value: "c49e551f9f68f2e024a8a50e35f2ce4a6ec86f169d9bfb489b47fa6e8e216571"
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ROUTE_HTTPS_PORT
+                  value: ""
+                - name: ROUTE_HTTP_PORT
+                  value: ""
+                - name: CLUSTER_NAME
+                  value: ""
+                - name: VERSION
+                  value: ""
                 image: quay.io/opencloudio/ibm-management-ingress-operator:1.2.0
                 imagePullPolicy: Always
                 name: ibm-management-ingress-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -63,3 +63,15 @@ spec:
               value: "ibm-management-ingress-operator"
             - name: OPERAND_IMAGE_DIGEST
               value: ""
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ROUTE_HTTPS_PORT
+              value: ""
+            - name: ROUTE_HTTP_PORT
+              value: ""
+            - name: CLUSTER_NAME
+              value: ""
+            - name: VERSION
+              value: ""

--- a/pkg/controller/managementingress/handler/constants.go
+++ b/pkg/controller/managementingress/handler/constants.go
@@ -40,4 +40,34 @@ const (
 	ProductID      string = "068a62892a1e4db39641342e592daa25"
 	ProductVersion string = "3.3.0"
 	ProductMetric  string = "FREE"
+
+	// ClusterConfigName ... ibmcloud-cluster-info
+	ClusterConfigName string = "ibmcloud-cluster-info"
+	ClusterAddr       string = "cluster_address"
+	ClusterCADomain   string = "cluster_ca_domain"
+	RouteBaseDomain   string = "openshift_router_base_domain"
+	ClusterEP         string = "cluster_endpoint"
+
+	RouteHTTPPort      string = "cluster_router_http_port"
+	RouteHTTPPortValue string = "80"
+	RouteHTTPPortEnv   string = "ROUTE_HTTP_PORT"
+
+	RouteHTTPSPort      string = "cluster_router_https_port"
+	RouteHTTPSPortValue string = "443"
+	RouteHTTPSPortEnv   string = "ROUTE_HTTPS_PORT"
+
+	ClusterName      string = "cluster_name"
+	ClusterNameValue string = "mycluster"
+	ClusterNameEnv   string = "CLUSTER_NAME"
+
+	ProxyAddr string = "proxy_address"
+	ProxyName string = "cp-proxy"
+
+	CSVersion      string = "version"
+	CSVersionValue string = "3.4.0"
+	CSVersionEnv   string = "VERSION"
+
+	PODNAMESPACE string = "POD_NAMESPACE"
+
+	ClusterSecretName string = "ibmcloud-cluster-ca-cert"
 )


### PR DESCRIPTION
Tested on OCP 4.3.
```
[root@thymine-inf ibm-management-ingress-operator]# oc get configmap ibmcloud-cluster-info -o yaml
apiVersion: v1
data:
  cluster_address: icp-console.apps.thymine.os.fyre.ibm.com
  cluster_ca_domain: icp-console.apps.thymine.os.fyre.ibm.com
  cluster_endpoint: https://icp-management-ingress.ibm-common-services.svc:443
  cluster_name: mycluster
  cluster_router_http_port: "80"
  cluster_router_https_port: "443"
  openshift_router_base_domain: apps.thymine.os.fyre.ibm.com
  version: 3.2.4
kind: ConfigMap
metadata:
  creationTimestamp: "2020-05-07T07:29:34Z"
  labels:
    app: management-ingress
    app.kubernetes.io/component: management-ingress
    app.kubernetes.io/instance: icp-management-ingress
    app.kubernetes.io/managed-by: ""
    app.kubernetes.io/name: management-ingress
    component: management-ingress
  name: ibmcloud-cluster-info
  namespace: ibm-common-services
  ownerReferences:
  - apiVersion: operator.ibm.com/v1
    controller: true
    kind: ManagementIngress
    name: default
    uid: ffaf6de3-b7e3-4c47-ba7c-7d48be500177
  resourceVersion: "2741348"
  selfLink: /api/v1/namespaces/ibm-common-services/configmaps/ibmcloud-cluster-info
  uid: 3cd7d7d7-5dbc-4192-a9f3-0dfcc43a316c
```
```
[root@thymine-inf ibm-management-ingress-operator]# oc get secret ibmcloud-cluster-ca-cert -o yaml
apiVersion: v1
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNakNDQWhxZ0F3SUJBZ0lSQU03YjJOeEtGN1BoTmIxKzllcXpBTnd3RFFZSktvWklodmNOQVFFTEJRQXcKTXpFVk1CTUdBMVVFQ2hNTVkyVnlkQzF0WVc1aFoyVnlNUm93R0FZRFZRUURFeEZqY3kxallTMWpaWEowYVdacApZMkYwWlRBZUZ3MHlNREExTURjd056RTJNVGhhRncweU1EQTRNRFV3TnpFMk1UaGFNRE14RlRBVEJnTlZCQW9UCkRHTmxjblF0YldGdVlXZGxjakVhTUJnR0ExVUVBeE1SWTNNdFkyRXRZMlZ5ZEdsbWFXTmhkR1V3Z2dFaU1BMEcKQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURSTUVsQzJvenZJaW5PN3I1T3NDYjREOVhSQVZUQgpvU0E0QkV6YW93TENRS1FvUmEvd1VqWjVRMzFiOUZneVh2aGlCR3EvNVJkY0ZtVnN3VjhwRFV2SnM1UEk5MEs5CklKb2tySkRVWllZSy9uNkc0ZVRkS1JXekErcG40c3VpQXN5V2gzTWtBNEhVODNZOTdVTkZaWm05Ujd0VG8yTGgKQlpCam5YR25EY0N3UXdMcEJsUlBTUjZEZW9hRnpwdkVnMElNbFllekpNbVVpL2pROFMvMlA4cXVMVldyT1EzdgovUVFwdlgwM0lFTXZwOVZ2NzFGQXlQOHZ5WWh5R1dSK0ltSHhxd2NrQmhDMW01WUI4OFpqcWpaZHYwRlIzUURZCmhrNXc1WjExR2RYbHpzeU5FajRvY0dNR1E4TEZFOFcxaDE3alBlRGUyaGtKbTlrM3I2QmN2VHVIQWdNQkFBR2oKUVRBL01BNEdBMVVkRHdFQi93UUVBd0lDcERBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUJ3R0ExVWRFUVFWTUJPQwpFV056TFdOaExXTmxjblJwWm1sallYUmxNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUEwcXgyamRoY05XNHp6Cm1FNjZuMlh1cy8wOWNxbTJ2NURLSHl2b2ZHSjNIVS80YXp4ZHM3UTd0clNJcUZOWlc1MjJQSVlIZHFoV2V0TFkKdlR2c0Ntdy9CK0xyczNKUVJheFgrby9lTm5QeW9yU04xc3J3YjlCM0FzL25yUDE1OUtRZHgrOGFqV3AzcmJYUQpmTTRtdllBanJJUmlDSXdieW56TS93TXVaTCtYeG03UHBnTzlDdFlsYmpjZlI2di9LTHhobk12SXZzbjRiREEzCkI2TUpGVDN0bERCYnJ5aE5yVjRUc05EY1JDRm5Ndkc3eTVrMWE1LzRIZ3NyZmJuYTJCOE04alFsYjZLTGpka08KaTdBQkc5NGIvWTdJcGY4a2xDbFJhRW1FVTV5d0gvLzJtMVdGd1N4YlBadDRLNUJIc1lMeVNVWUFjWXhZaFZPQQpVMTZWclo4NAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
kind: Secret
metadata:
  creationTimestamp: "2020-05-07T07:30:03Z"
  labels:
    app: management-ingress
    app.kubernetes.io/component: management-ingress
    app.kubernetes.io/instance: icp-management-ingress
    app.kubernetes.io/managed-by: ""
    app.kubernetes.io/name: management-ingress
    component: management-ingress
  name: ibmcloud-cluster-ca-cert
  namespace: ibm-common-services
  resourceVersion: "2727122"
  selfLink: /api/v1/namespaces/ibm-common-services/secrets/ibmcloud-cluster-ca-cert
  uid: 52446988-8fe7-4dee-aa81-5f43ba1a3b98
type: Opaque
```

Signed-off-by: Wei Yu (Jared) <yuweiw@.cn.ibm.com>