### PR TITLE
Remove prefix https:// from api server address.

### DIFF
--- a/pkg/controller/managementingress/handler/configmap.go
+++ b/pkg/controller/managementingress/handler/configmap.go
@@ -253,6 +253,9 @@ func populateCloudClusterInfo(ingressRequest *IngressRequest) error {
 			for k1, v1 := range cinfo {
 				if k1.(string) == ConsoleMasterURL {
 					apiaddr = v1.(string)
+					if strings.HasPrefix(apiaddr, "https://") {
+						apiaddr = apiaddr[8:]
+					}
 					break
 				}
 			}


### PR DESCRIPTION
```
apiVersion: v1
data:
  cluster_address: cp-console.apps.thymine.os.fyre.ibm.com
  cluster_ca_domain: cp-console.apps.thymine.os.fyre.ibm.com
  cluster_endpoint: https://icp-management-ingress.ibm-common-services.svc:443
  cluster_kube_apiserver_host: api.thymine.os.fyre.ibm.com
  cluster_kube_apiserver_port: "6443"
  cluster_name: mycluster
  cluster_router_http_port: "80"
  cluster_router_https_port: "443"
  openshift_router_base_domain: apps.thymine.os.fyre.ibm.com
  proxy_address: cp-proxy.apps.thymine.os.fyre.ibm.com
  version: 3.4.0
kind: ConfigMap
metadata:
  creationTimestamp: "2020-05-12T07:18:01Z"
  labels:
    app: management-ingress
    app.kubernetes.io/component: management-ingress
    app.kubernetes.io/instance: icp-management-ingress
    app.kubernetes.io/managed-by: ""
    app.kubernetes.io/name: management-ingress
    component: management-ingress
  name: ibmcloud-cluster-info
  namespace: ibm-common-services
  ownerReferences:
  - apiVersion: operator.ibm.com/v1alpha1
    controller: true
    kind: ManagementIngress
    name: default
    uid: e10339f1-2fcc-4402-b683-ef171764e9d4
  resourceVersion: "6576745"
  selfLink: /api/v1/namespaces/ibm-common-services/configmaps/ibmcloud-cluster-info
  uid: 640fcc87-49d1-41b7-8357-c5a24cf475ad
```


Signed-off-by: Wei Yu (Jared) <yuweiw@.cn.ibm.com>