### PR TITLE
Add key usage for certificate used by management ingress

### DIFF
--- a/pkg/controller/managementingress/handler/cert.go
+++ b/pkg/controller/managementingress/handler/cert.go
@@ -55,6 +55,7 @@ func NewCertificate(name, namespace, secret string, hosts, ips []string, issuer 
 			},
 			DNSNames:    hosts,
 			IPAddresses: ips,
+			Usages:      []certmanager.KeyUsage{certmanager.UsageDigitalSignature, certmanager.UsageKeyEncipherment, certmanager.UsageServerAuth},
 		},
 	}
 }


### PR DESCRIPTION
There is ERR_CERT_INVALID error if open common service UI with
Chrome browser. It turns out key usage "server auth" is missed
because of Apple's strict security check https://support.apple.com/en-us/HT211025
So add the key usage for the case.