### PR TITLE
Fix issue routeHost is not working as expected

### DIFF
--- a/pkg/controller/managementingress/handler/configmap.go
+++ b/pkg/controller/managementingress/handler/configmap.go
@@ -268,8 +268,8 @@ func populateCloudClusterInfo(ingressRequest *IngressRequest) error {
 		ClusterConfigName,
 		ingressRequest.managementIngress.Namespace,
 		map[string]string{
-			ClusterAddr:          RouteName + "." + baseDomain,
-			ClusterCADomain:      RouteName + "." + baseDomain,
+			ClusterAddr:          ingressRequest.managementIngress.Status.Host,
+			ClusterCADomain:      ingressRequest.managementIngress.Status.Host,
 			ClusterEP:            ep,
 			ClusterName:          cname,
 			RouteHTTPPort:        rhttpPort,


### PR DESCRIPTION
If user specify routeHost in the CR we should set the route host
not only in route resource, but also in configmap managed.