### PR TITLE
Clean up cluster resource in finalizer

### DIFF
--- a/deploy/crds/operator.ibm.com_managementingresses_crd.yaml
+++ b/deploy/crds/operator.ibm.com_managementingresses_crd.yaml
@@ -76,9 +76,6 @@ spec:
                   type: string
                 tag:
                   type: string
-              required:
-              - repository
-              - tag
               type: object
             imageRegistry:
               type: string

--- a/deploy/olm-catalog/ibm-management-ingress-operator/1.3.1/ibm-management-ingress-operator.v1.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-management-ingress-operator/1.3.1/ibm-management-ingress-operator.v1.3.1.clusterserviceversion.yaml
@@ -256,6 +256,30 @@ spec:
           - list
           - use
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          resourceNames:
+          - management-ingress
+          verbs:
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          resourceNames:
+          - management-ingress
+          verbs:
+          - delete
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - management-ingress-scc
+          verbs:
+          - delete
+        - apiGroups:
           - certmanager.k8s.io
           resources:
           - clusterissuers
@@ -271,44 +295,42 @@ spec:
           - list
           - watch
         - apiGroups:
-            - "extensions"
-            - "networking.k8s.io"
+          - "extensions"
+          - "networking.k8s.io"
           resources:
-            - ingresses
+          - ingresses
           verbs:
-            - get
-            - list
-            - watch
+          - get
+          - list
+          - watch
         - apiGroups:
-            - "extensions"
-            - "networking.k8s.io"
+          - "extensions"
+          - "networking.k8s.io"
           resources:
-            - ingresses/status
+          - ingresses/status
           verbs:
-            - update
+          - update
         - apiGroups:
-            - "operator.openshift.io"
+          - "operator.openshift.io"
           resources:
-            - dnses
-            - ingresscontrollers
+          - dnses
+          - ingresscontrollers
           verbs:
-            - get
-            - list
-            - watch
+          - get
+          - list
+          - watch
         - apiGroups:
-            - ""
+          - ""
           resources:
-            - nodes
+          - nodes
           verbs:
-            - get
-            - list
-            - watch
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:
           - pods
-          - services
-          - services/finalizers
           - serviceaccounts
           - endpoints
           - persistentvolumeclaims
@@ -317,12 +339,34 @@ spec:
           - secrets
           verbs:
           - create
-          - delete
           - get
           - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - get
+          - list
+          - watch
           - patch
           - update
-          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - patch
+          - update
         - apiGroups:
           - apps
           resources:
@@ -332,10 +376,8 @@ spec:
           - statefulsets
           verbs:
           - create
-          - delete
           - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -350,15 +392,15 @@ spec:
           - operator.ibm.com
           resources:
           - managementingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - managementingresses/finalizers
           - managementingresses/status
           verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
           - update
-          - watch
         - apiGroups:
           - route.openshift.io
           resources:
@@ -387,13 +429,7 @@ spec:
           resources:
           - servicemonitors
           verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - '*'
         serviceAccountName: ibm-management-ingress-operator
     strategy: deployment
   installModes:

--- a/deploy/olm-catalog/ibm-management-ingress-operator/1.3.1/operator.ibm.com_managementingresses_crd.yaml
+++ b/deploy/olm-catalog/ibm-management-ingress-operator/1.3.1/operator.ibm.com_managementingresses_crd.yaml
@@ -74,9 +74,6 @@ spec:
                   type: string
                 tag:
                   type: string
-              required:
-              - repository
-              - tag
               type: object
             imageRegistry:
               type: string

--- a/pkg/controller/managementingress/handler/cert.go
+++ b/pkg/controller/managementingress/handler/cert.go
@@ -20,13 +20,13 @@ import (
 	"strings"
 	"time"
 
-	v1alph1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
-	"github.com/IBM/ibm-management-ingress-operator/pkg/utils"
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
-	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	v1alph1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
 )
 
 //NewCertificate stubs an instance of Certificate
@@ -100,81 +100,20 @@ func (ingressRequest *IngressRequest) CreateOrUpdateCertificates() error {
 		return err
 	}
 
-	// Delete the secret to make sure the TLS cert will be freshed by cert manager. Of course all related pods which
-	// refer to the secret need to be restarted.
-	// secret := &core.Secret{
-	// 	TypeMeta: metav1.TypeMeta{
-	// 		Kind:       "Secret",
-	// 		APIVersion: core.SchemeGroupVersion.String(),
-	// 	},
-	// 	ObjectMeta: metav1.ObjectMeta{
-	// 		Name:      TLSSecretName,
-	// 		Namespace: ingressRequest.managementIngress.ObjectMeta.Namespace,
-	// 	},
-	// 	Data: map[string][]byte{},
-	// }
-
-	// klog.V(4).Infof("Deleting related secret %q for the Certificate to force a refresh.", TLSSecretName)
-	// err = ingressRequest.Delete(secret)
-	// if err != nil && !errors.IsNotFound(err) {
-	// 	klog.Errorf("Failure deleting secret to force a refresh of cert: %v", err)
-	// }
-
 	ingressRequest.recorder.Eventf(ingressRequest.managementIngress, "Normal", "CreatedCertificate", "Successfully created certificate %q", CertName)
 
 	return nil
 }
 
 func (ingressRequest *IngressRequest) CreateCert(cert *certmanager.Certificate) error {
-	utils.AddOwnerRefToObject(cert, utils.AsOwner(ingressRequest.managementIngress))
+	if err := controllerutil.SetControllerReference(ingressRequest.managementIngress, cert, ingressRequest.scheme); err != nil {
+		klog.Errorf("Error setting controller reference on Certificate: %v", err)
+	}
 
 	klog.Infof("Creating Certificate: %s for %q.", cert.ObjectMeta.Name, ingressRequest.managementIngress.ObjectMeta.Name)
 	err := ingressRequest.Create(cert)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("Failure constructing certificate for %q: %v", ingressRequest.managementIngress.ObjectMeta.Name, err)
-	}
-
-	return nil
-}
-
-//RemoveCertificate with a given name and namespace
-func (ingressRequest *IngressRequest) RemoveCertificate(name string) error {
-	cert := &certmanager.Certificate{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Certificate",
-			APIVersion: "certmanager.k8s.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ingressRequest.managementIngress.ObjectMeta.Namespace,
-		},
-		Spec: certmanager.CertificateSpec{},
-	}
-
-	// Delete certificate
-	klog.Infof("Deleting Certificate for %q.", ingressRequest.managementIngress.ObjectMeta.Name)
-	err := ingressRequest.Delete(cert)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting %v certificate: %v", name, err)
-	}
-
-	// Also delete the secret managed by cert
-	secret := &core.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: core.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      TLSSecretName,
-			Namespace: ingressRequest.managementIngress.ObjectMeta.Namespace,
-		},
-		Data: map[string][]byte{},
-	}
-
-	klog.Infof("Deleting related Secret %s for the certificate too.", TLSSecretName)
-	err = ingressRequest.Delete(secret)
-	if err != nil && !errors.IsNotFound(err) {
-		klog.Errorf("Failure deleting secret of cert: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/managementingress/handler/constants.go
+++ b/pkg/controller/managementingress/handler/constants.go
@@ -60,7 +60,7 @@ const (
 	ClusterNameEnv   string = "CLUSTER_NAME"
 
 	CSVersion      string = "version"
-	CSVersionValue string = "3.4.0"
+	CSVersionValue string = "3.5.0"
 	CSVersionEnv   string = "VERSION"
 
 	PODNAMESPACE string = "POD_NAMESPACE"

--- a/pkg/controller/managementingress/handler/default.go
+++ b/pkg/controller/managementingress/handler/default.go
@@ -16,6 +16,7 @@
 package handler
 
 import (
+	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -26,3 +27,48 @@ var (
 	defaultMemoryLimit resource.Quantity = resource.MustParse("512Mi")
 	defaultCpuLimit    resource.Quantity = resource.MustParse("200m")
 )
+
+var defaultRules = []rbac.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"services"},
+		ResourceNames: nil,
+		Verbs: []string{"get", "list", "watch"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"endpoints", "nodes", "pods", "secrets"},
+		ResourceNames: nil,
+		Verbs: []string{"list", "watch"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"configmaps"},
+		ResourceNames: nil,
+		Verbs: []string{"create", "get", "list", "update", "watch"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"events"},
+		ResourceNames: nil,
+		Verbs: []string{"create", "patch"},
+	},
+	{
+		APIGroups: []string{"extensions", "networking.k8s.io"},
+		Resources: []string{"ingresses"},
+		ResourceNames: nil,
+		Verbs: []string{"get", "list", "watch"},
+	},
+	{
+		APIGroups: []string{"extensions", "networking.k8s.io"},
+		Resources: []string{"ingresses/status"},
+		ResourceNames: nil,
+		Verbs: []string{"update"},
+	},
+	{
+		APIGroups: []string{"security.openshift.io"},
+		Resources: []string{"securitycontextconstraints"},
+		ResourceNames: []string{SCCName},
+		Verbs: []string{"use"},
+	},
+}

--- a/pkg/controller/managementingress/handler/ingressrequest.go
+++ b/pkg/controller/managementingress/handler/ingressrequest.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,12 +28,25 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
 )
 
 type IngressRequest struct {
 	client            client.Client
 	managementIngress *v1alpha1.ManagementIngress
 	recorder          record.EventRecorder
+	scheme            *runtime.Scheme
+}
+
+func NewIngressHandler(instance *v1alpha1.ManagementIngress, c client.Client, r record.EventRecorder, s *runtime.Scheme) *IngressRequest {
+
+	return &IngressRequest{
+		managementIngress: instance,
+		client:            c,
+		recorder:          r,
+		scheme:            s,
+	}
 }
 
 func (ingressRequest *IngressRequest) isManaged() bool {

--- a/pkg/controller/managementingress/handler/scc.go
+++ b/pkg/controller/managementingress/handler/scc.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/IBM/ibm-management-ingress-operator/pkg/utils"
 	scc "github.com/openshift/api/security/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -77,8 +76,6 @@ func (ingressRequest *IngressRequest) CreateSecurityContextConstraint() error {
 		ingressRequest.managementIngress.Namespace,
 	)
 
-	utils.AddOwnerRefToObject(scc, utils.AsOwner(ingressRequest.managementIngress))
-
 	klog.Infof("Creating SecurityContextConstraint %q for %q.", SCCName, ingressRequest.managementIngress.Name)
 	err := ingressRequest.Create(scc)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -102,7 +99,7 @@ func (ingressRequest *IngressRequest) RemoveSecurityContextConstraint(name strin
 		},
 	}
 
-	klog.Infof("Removing SecurityContextConstraint for %q.", ingressRequest.managementIngress.Name)
+	klog.Infof("Removing SecurityContextConstraint .", name)
 	err := ingressRequest.Delete(scc)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("Failure deleting %v SecurityContextConstraint %v", name, err)

--- a/pkg/controller/managementingress/handler/serviceaccount.go
+++ b/pkg/controller/managementingress/handler/serviceaccount.go
@@ -18,12 +18,12 @@ package handler
 import (
 	"fmt"
 
-	"github.com/IBM/ibm-management-ingress-operator/pkg/utils"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func NewServiceAccount(name string, namespace string) *core.ServiceAccount {
@@ -48,7 +48,9 @@ func (ingressRequest *IngressRequest) CreateServiceAccount() error {
 		ServiceAccountName,
 		ingressRequest.managementIngress.Namespace)
 
-	utils.AddOwnerRefToObject(sa, utils.AsOwner(ingressRequest.managementIngress))
+	if err := controllerutil.SetControllerReference(ingressRequest.managementIngress, sa, ingressRequest.scheme); err != nil {
+		klog.Error("Error setting controller reference on ServiceAccount: %v", err)
+	}
 
 	klog.Infof("Creating ServiceAccount %q for %q.", ServiceAccountName, ingressRequest.managementIngress.Name)
 	err := ingressRequest.Create(sa)
@@ -57,53 +59,8 @@ func (ingressRequest *IngressRequest) CreateServiceAccount() error {
 	}
 
 	// Create required clusterRole
-	clusterrules := NewPolicyRules(
-		NewPolicyRule(
-			[]string{""},
-			[]string{"services"},
-			nil,
-			[]string{"get", "list", "watch"},
-		),
-		NewPolicyRule(
-			[]string{""},
-			[]string{"endpoints", "nodes", "pods", "secrets"},
-			nil,
-			[]string{"list", "watch"},
-		),
-		NewPolicyRule(
-			[]string{""},
-			[]string{"configmaps"},
-			nil,
-			[]string{"create", "get", "list", "update", "watch"},
-		),
-		NewPolicyRule(
-			[]string{""},
-			[]string{"events"},
-			nil,
-			[]string{"create", "patch"},
-		),
-		NewPolicyRule(
-			[]string{"extensions", "networking.k8s.io"},
-			[]string{"ingresses"},
-			nil,
-			[]string{"get", "list", "watch"},
-		),
-		NewPolicyRule(
-			[]string{"extensions", "networking.k8s.io"},
-			[]string{"ingresses/status"},
-			nil,
-			[]string{"update"},
-		),
-		NewPolicyRule(
-			[]string{"security.openshift.io"},
-			[]string{"securitycontextconstraints"},
-			[]string{SCCName},
-			[]string{"use"},
-		),
-	)
-
 	klog.Infof("Creating ClusterRole: %q for %q.", AppName, ingressRequest.managementIngress.Name)
-	_, err = ingressRequest.CreateClusterRole(AppName, clusterrules)
+	_, err = ingressRequest.CreateClusterRole(AppName, defaultRules)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("Failure constructing ClusterRole for %q: %v", ingressRequest.managementIngress.Name, err)
 	}
@@ -128,64 +85,6 @@ func (ingressRequest *IngressRequest) CreateServiceAccount() error {
 		return fmt.Errorf("Failure constructing ClusterRoleBinding for %q: %v", ingressRequest.managementIngress.Name, err)
 	}
 	ingressRequest.recorder.Eventf(ingressRequest.managementIngress, "Normal", "CreatedServiceAccount", "Successfully created service account %q", ServiceAccountName)
-
-	return nil
-}
-
-//RemoveService with given name and namespace
-func (ingressRequest *IngressRequest) RemoveServiceAccount(name string) error {
-
-	klog.V(4).Infof("Deleting related ClusterRole for ManagementIngress %q.", ingressRequest.managementIngress.Name)
-	clusterRole := &rbac.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: rbac.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: AppName,
-		},
-		Rules: []rbac.PolicyRule{},
-	}
-	err := ingressRequest.Delete(clusterRole)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting ClusterRole: %v", err)
-	}
-
-	klog.V(4).Infof("Deleting related ClusterRoleBingding for ManagementIngress %q.", ingressRequest.managementIngress.Name)
-	clusterRoleBinding := &rbac.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRoleBinding",
-			APIVersion: rbac.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: AppName,
-		},
-		RoleRef:  rbac.RoleRef{},
-		Subjects: []rbac.Subject{},
-	}
-	err = ingressRequest.Delete(clusterRoleBinding)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting ClusterRoleBinding: %v", err)
-	}
-
-	klog.Infof("Deleting SerrviceAccount: %q for ManagementIngress %q.", name, ingressRequest.managementIngress.Name)
-	sa := &core.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
-			APIVersion: core.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ingressRequest.managementIngress.Namespace,
-		},
-	}
-
-	err = ingressRequest.Delete(sa)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting %v ServiceAccount %v", name, err)
-	}
-
-	klog.Infof("Successfully removed SerrviceAccount, ClusterRole, ClusterRoleBingding for ManagementIngress %q.", ingressRequest.managementIngress.Name)
 
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,10 +18,11 @@ package utils
 import (
 	"reflect"
 
-	v1alpha1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/IBM/ibm-management-ingress-operator/pkg/apis/operator/v1alpha1"
 )
 
 // GetAnnotation returns the value of an annoation for a given key and true if the key was found
@@ -99,13 +100,6 @@ func AppendTolerations(lhsTolerations, rhsTolerations []core.Toleration) []core.
 	}
 
 	return append(lhsTolerations, rhsTolerations...)
-}
-
-//AddOwnerRefToObject adds the parent as an owner to the child
-func AddOwnerRefToObject(object metav1.Object, ownerRef metav1.OwnerReference) {
-	if (metav1.OwnerReference{}) != ownerRef {
-		object.SetOwnerReferences(append(object.GetOwnerReferences(), ownerRef))
-	}
 }
 
 func GetBool(value bool) *bool {


### PR DESCRIPTION
Management ingress CR is namespace scoped. It should own cluster
resources like clusterrole, clusterroleding and scc. We see a
race condition issue in k8s GC which will remove all resources
created by management ingress operator in such case. Just move
the clean up in finalizer.