### PR TITLE
Create cp-proxy route

### DIFF
--- a/pkg/apis/addtoscheme_operator_v1alpha1.go
+++ b/pkg/apis/addtoscheme_operator_v1alpha1.go
@@ -19,7 +19,6 @@ import (
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	operator "github.com/openshift/api/operator/v1"
 	route "github.com/openshift/api/route/v1"
-	scc "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
@@ -30,20 +29,17 @@ var (
 	// CertSchemeGroupVersion is group version used to register these objects
 	CertSchemeGroupVersion     = schema.GroupVersion{Group: "certmanager.k8s.io", Version: "v1alpha1"}
 	RouteSchemeGroupVersion    = schema.GroupVersion{Group: "route.openshift.io", Version: "v1"}
-	SCCSchemeGroupVersion      = schema.GroupVersion{Group: "security.openshift.io", Version: "v1"}
 	OperatorSchemeGroupVersion = schema.GroupVersion{Group: "operator.openshift.io", Version: "v1"}
 
 	// CertSchemeBuilder is used to add go types to the GroupVersionKind scheme
 	CertSchemeBuilder     = &scheme.Builder{GroupVersion: CertSchemeGroupVersion}
 	RouteSchemeBuilder    = &scheme.Builder{GroupVersion: RouteSchemeGroupVersion}
-	SCCSchemeBuilder      = &scheme.Builder{GroupVersion: SCCSchemeGroupVersion}
 	OperatorSchemeBuilder = &scheme.Builder{GroupVersion: OperatorSchemeGroupVersion}
 )
 
 func init() {
 	CertSchemeBuilder.Register(&certmanager.Certificate{})
 	RouteSchemeBuilder.Register(&route.Route{})
-	SCCSchemeBuilder.Register(&scc.SecurityContextConstraints{})
 	OperatorSchemeBuilder.Register(&operator.IngressController{})
 	OperatorSchemeBuilder.Register(&operator.IngressControllerList{})
 	OperatorSchemeBuilder.Register(&operator.DNS{})
@@ -51,5 +47,5 @@ func init() {
 
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and bac
 	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme, CertSchemeBuilder.AddToScheme,
-		RouteSchemeBuilder.AddToScheme, SCCSchemeBuilder.AddToScheme, OperatorSchemeBuilder.AddToScheme)
+		RouteSchemeBuilder.AddToScheme, OperatorSchemeBuilder.AddToScheme)
 }

--- a/pkg/controller/managementingress/handler/configmap.go
+++ b/pkg/controller/managementingress/handler/configmap.go
@@ -65,7 +65,7 @@ func patchOrCreateConfigmap(ingr *IngressRequest, cm *core.ConfigMap) error {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// create configmap
-			klog.Infof("Creating Configmap %s.", cm.ObjectMeta.Name)
+			klog.Infof("Creating configmap %s.", cm.ObjectMeta.Name)
 			err = ingr.Create(cm)
 			if err != nil {
 				ingr.recorder.Eventf(ingr.managementIngress, "Warning", "CreatedConfigmap", "Failure creating configmap %q: %v", cm.ObjectMeta.Name, err)
@@ -187,6 +187,7 @@ func (ingressRequest *IngressRequest) CreateOrUpdateConfigMap() error {
 		return fmt.Errorf("failure creating bind info for %q: %v", ingressRequest.managementIngress.Name, err)
 	}
 
+	// Create ibmcloud-cluster-info
 	if err := populateCloudClusterInfo(ingressRequest); err != nil {
 		return fmt.Errorf("failure populate cloud cluster info for %q: %v", ingressRequest.managementIngress.Name, err)
 	}
@@ -268,7 +269,7 @@ func populateCloudClusterInfo(ingressRequest *IngressRequest) error {
 			CSVersion:            ver,
 			ClusterAPIServerHost: apiaddr[0:pos],
 			ClusterAPIServerPort: apiaddr[pos+1:],
-			ProxyAddress:         "cp-proxy." + baseDomain,
+			ProxyAddress:         ProxyRouteName + "." + baseDomain,
 			ProxyHTTPPort:        "80",
 			ProxyHTTPSPort:       "443",
 		},

--- a/pkg/controller/managementingress/handler/constants.go
+++ b/pkg/controller/managementingress/handler/constants.go
@@ -60,7 +60,7 @@ const (
 	ClusterNameEnv   string = "CLUSTER_NAME"
 
 	CSVersion      string = "version"
-	CSVersionValue string = "3.5.0"
+	CSVersionValue string = "3.6.0"
 	CSVersionEnv   string = "VERSION"
 
 	PODNAMESPACE string = "POD_NAMESPACE"
@@ -77,4 +77,7 @@ const (
 	ProxyAddress         string = "proxy_address"
 	ProxyHTTPPort        string = "proxy_ingress_http_port"
 	ProxyHTTPSPort       string = "proxy_ingress_https_port"
+
+	ProxyRouteName   string = "cp-proxy"
+	ProxyServiceName string = "nginx-ingress-controller"
 )

--- a/pkg/controller/managementingress/handler/deployment.go
+++ b/pkg/controller/managementingress/handler/deployment.go
@@ -335,9 +335,7 @@ func (ingressRequest *IngressRequest) CreateOrUpdateDeployment() error {
 			klog.Infof("No change found from the deployment: %s.", AppName)
 			return nil
 		}
-		klog.Infof("Found change from Deployment Replicas %d. Trying to update it.", ingressRequest.managementIngress.Spec.Replicas)
-
-		klog.Infof("Found change from Deployment %+v. Trying to update it.", podSpec)
+		klog.Infof("Found change for deployment: %s. Trying to update it.", AppName)
 		err = ingressRequest.Update(desired)
 		if err != nil {
 			ingressRequest.recorder.Eventf(ingressRequest.managementIngress, "Warning", "UpdatedDeployment", "Failure updating deployment %q: %v", AppName, err)


### PR DESCRIPTION
Because the route resource of ingress nginx was created in the
post install hook, this resource cannot be fully managed by operator.
Move route resource in this operator which will act as parent operator
to manage both route resources.