### PR TITLE
Update owner reference of cp-proxy route

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -137,7 +138,9 @@ func main() {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		klog.Errorf("Could not create ServiceMonitor object", "error", err.Error())
+		if !errors.IsAlreadyExists(err) {
+			klog.Errorf("Could not create ServiceMonitor object", "error", err.Error())
+		}
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
 		if err == metrics.ErrServiceMonitorNotPresent {

--- a/deploy/olm-catalog/ibm-management-ingress-operator/1.4.0/ibm-management-ingress-operator.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-management-ingress-operator/1.4.0/ibm-management-ingress-operator.v1.4.0.clusterserviceversion.yaml
@@ -300,10 +300,13 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          - routes/finalizers
           verbs:
           - create
           - get
+          - delete
           - list
+          - update
           - watch
         - apiGroups:
           - route.openshift.io

--- a/pkg/apis/addtoscheme_operator_v1alpha1.go
+++ b/pkg/apis/addtoscheme_operator_v1alpha1.go
@@ -39,7 +39,9 @@ var (
 
 func init() {
 	CertSchemeBuilder.Register(&certmanager.Certificate{})
+	CertSchemeBuilder.Register(&certmanager.CertificateList{})
 	RouteSchemeBuilder.Register(&route.Route{})
+	RouteSchemeBuilder.Register(&route.RouteList{})
 	OperatorSchemeBuilder.Register(&operator.IngressController{})
 	OperatorSchemeBuilder.Register(&operator.IngressControllerList{})
 	OperatorSchemeBuilder.Register(&operator.DNS{})

--- a/pkg/controller/managementingress/handler/service.go
+++ b/pkg/controller/managementingress/handler/service.go
@@ -69,11 +69,16 @@ func (ingressRequest *IngressRequest) CreateOrUpdateService() error {
 		klog.Errorf("Error setting controller reference on Service: %v", err)
 	}
 
-	klog.Infof("Creating Service %q for %q.", ServiceName, ingressRequest.managementIngress.Name)
 	err := ingressRequest.Create(service)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return nil
+		}
+
 		return fmt.Errorf("failure constructing service for %q: %v", ingressRequest.managementIngress.Name, err)
 	}
+
+	klog.Infof("Created Service: %q.", ServiceName)
 	ingressRequest.recorder.Eventf(ingressRequest.managementIngress, "Normal", "CreatedService", "Successfully created service %q", ServiceName)
 
 	return nil

--- a/pkg/controller/managementingress/managementingress_controller.go
+++ b/pkg/controller/managementingress/managementingress_controller.go
@@ -57,12 +57,6 @@ var (
 		{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
 	}
 
-	// watchedClusterResources = []schema.GroupVersionKind{
-	// 	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
-	// 	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
-	// 	{Group: "security.openshift.io", Version: "v1", Kind: "SecurityContextConstraints"},
-	// }
-
 	ownedResourcePredicates = predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -171,6 +165,7 @@ func (r *ReconcileManagementIngress) Reconcile(request reconcile.Request) (recon
 	if instance.Spec.ManagementState == v1alpha1.ManagementStateUnmanaged {
 		return reconcile.Result{}, nil
 	}
+
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		klog.Infof("Instance: %s/%s was deleted. Do nothing!", request.NamespacedName.Namespace, request.NamespacedName.Name)
 		return reconcile.Result{}, nil
@@ -178,41 +173,6 @@ func (r *ReconcileManagementIngress) Reconcile(request reconcile.Request) (recon
 
 	klog.Info("Reconciling ManagementIngress")
 	i := k8shandler.NewIngressHandler(instance, r.client, r.eClient, r.recorder, r.scheme)
-
-	// // examine DeletionTimestamp to determine if object is under deletion
-	// if instance.ObjectMeta.DeletionTimestamp.IsZero() {
-	// 	// The object is not being deleted, so if it does not have our finalizer,
-	// 	// then lets add the finalizer and update the object. This is equivalent
-	// 	// registering our finalizer.
-	// 	if !k8sutils.ContainsString(instance.ObjectMeta.Finalizers, finalizerName) {
-	// 		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, finalizerName)
-	// 		if err := r.client.Update(context.Background(), instance); err != nil {
-	// 			klog.Errorf("Failed to add finalizer: ", err)
-	// 			return reconcile.Result{}, err
-	// 		}
-	// 	}
-	// } else {
-	// 	// The object is being deleted
-	// 	if k8sutils.ContainsString(instance.ObjectMeta.Finalizers, finalizerName) {
-	// 		// our finalizer is present, so lets handle any external dependency
-	// 		if err := k8shandler.DeleteClusterResources(i); err != nil {
-	// 			// if fail to delete the external dependency here, return with error
-	// 			// so that it can be retried
-	// 			klog.Errorf("Failed to delete cluster resources: ", err)
-	// 			return reconcile.Result{}, err
-	// 		}
-
-	// 		// remove our finalizer from the list and update it.
-	// 		instance.ObjectMeta.Finalizers = k8sutils.RemoveString(instance.ObjectMeta.Finalizers, finalizerName)
-	// 		if err := r.client.Update(context.Background(), instance); err != nil {
-	// 			klog.Errorf("Failed to remove finalizer: ", err)
-	// 			return reconcile.Result{}, err
-	// 		}
-	// 	}
-
-	// 	// Stop reconciliation as the item is being deleted
-	// 	return reconcile.Result{}, nil
-	// }
 
 	err = k8shandler.Reconcile(i)
 	if err != nil {


### PR DESCRIPTION
In upgrade case need to upgrade owner reference of cp-proxy route.
Just make sure the route resource will be GCed by k8s in uninstallation
case.