### PR TITLE
Fix build problem

### DIFF
--- a/bundle/manifests/operator.ibm.com_managementingresses.yaml
+++ b/bundle/manifests/operator.ibm.com_managementingresses.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
There is format error when we build operator bundle image. Remove
the first two lines of CRD definition for correct the format of
bundle manifest.