### PR TITLE
Add cncf cluster domain fix

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - bluzarraga
-- fatihertinaz
 - horis233
-- mamabusi
-- rgtoronto
+- siddarthpatel
+- sgrube

--- a/controllers/handler/deployment.go
+++ b/controllers/handler/deployment.go
@@ -294,12 +294,20 @@ func getClusterDomain(clusterType string) (string, error) {
 		cname, err := net.LookupCNAME(apiSvc)
 
 		if err != nil {
+			klog.Info("Inside default cluster domain")
 			defaultClusterDomain := "cluster.local"
 			return defaultClusterDomain, nil
 		}
 
-		clusterDomain := strings.TrimPrefix(cname, apiSvc)
+		klog.Infof("cname is : %s", cname)
+
+		prefixTrim := "kubernetes.default.svc."
+		clusterDomain := strings.TrimPrefix(cname, prefixTrim)
+		klog.Infof("Cluster domain after trimming prefix from cname is : %s", clusterDomain)
+
 		clusterDomain = strings.TrimSuffix(clusterDomain, ".")
+		klog.Infof("Cluster domain after trimming suffix : %s", clusterDomain)
+
 		return clusterDomain, nil
 	}
 


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/52365

Bug had to do with an extra `.` in the domain prefix

Before fix logs:
<img width="879" alt="Screen Shot 2022-03-02 at 3 35 31 PM" src="https://user-images.githubusercontent.com/17713495/156449711-397f92fd-31c3-4431-b842-b69431530281.png">

After fix logs:
<img width="543" alt="Screen Shot 2022-03-02 at 4 04 22 PM" src="https://user-images.githubusercontent.com/17713495/156449735-351f4818-dfe2-4ff9-a6a2-30e177f6ba57.png">


